### PR TITLE
Update Icon search location

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -8,7 +8,7 @@ class AnimationFreeCAD(Workbench):
 
         self.__class__.MenuText = "AnimationFreeCAD"
         self.__class__.ToolTip = "Faire des animations"
-        self.__class__.Icon = os.path.join(App.getResourceDir(),"../"
+        self.__class__.Icon = os.path.join(App.getUserAppDataDir(),
                                            "Mod", "AnimationFreeCAD",
                                            "icons",
                                            "clapCinema.svg")


### PR DESCRIPTION
To use the icon included with a new download of this Addon, you should set the path to the icon relative to the Addon installation location.